### PR TITLE
Change enum names to avoid conflicts with other plugins

### DIFF
--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -46,13 +46,13 @@
 
 - (NSString*)w3cConnectionTypeFor:(CDVReachability*)reachability
 {
-    NetworkStatus networkStatus = [reachability currentReachabilityStatus];
+    NetworkStatusReachability networkStatus = [reachability currentReachabilityStatus];
 
     switch (networkStatus) {
-        case NotReachable:
+        case UnReachable:
             return @"none";
 
-        case ReachableViaWWAN:
+        case ReachableOnWWAN:
         {
             BOOL isConnectionRequired = [reachability connectionRequired];
             if (isConnectionRequired) {
@@ -87,7 +87,7 @@
                 return @"cellular";
             }
         }
-        case ReachableViaWiFi:
+        case ReachableOnWiFi:
         {
             BOOL isConnectionRequired = [reachability connectionRequired];
             if (isConnectionRequired) {

--- a/src/ios/CDVReachability.h
+++ b/src/ios/CDVReachability.h
@@ -49,10 +49,10 @@
 #import <netinet/in.h>
 
 typedef enum {
-    NotReachable = 0,
-    ReachableViaWWAN, // this value has been swapped with ReachableViaWiFi for Cordova backwards compat. reasons
-    ReachableViaWiFi  // this value has been swapped with ReachableViaWWAN for Cordova backwards compat. reasons
-} NetworkStatus;
+    UnReachable = 0,
+    ReachableOnWWAN, // this value has been swapped with ReachableViaWiFi for Cordova backwards compat. reasons
+    ReachableOnWiFi  // this value has been swapped with ReachableViaWWAN for Cordova backwards compat. reasons
+} NetworkStatusReachability;
 #define kReachabilityChangedNotification @"kNetworkReachabilityChangedNotification"
 
 @interface CDVReachability : NSObject
@@ -74,7 +74,7 @@ typedef enum {
 - (BOOL)startNotifier;
 - (void)stopNotifier;
 
-- (NetworkStatus)currentReachabilityStatus;
+- (NetworkStatusReachability)currentReachabilityStatus;
 // WWAN may be available, but not active until a connection has been established.
 // WiFi may require a connection for VPN on Demand.
 - (BOOL)connectionRequired;

--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -178,20 +178,20 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 
 #pragma mark Network Flag Handling
 
-- (NetworkStatus)networkStatusForFlags:(SCNetworkReachabilityFlags)flags
+- (NetworkStatusReachability)networkStatusForFlags:(SCNetworkReachabilityFlags)flags
 {
     CDVPrintReachabilityFlags(flags, "networkStatusForFlags");
     if ((flags & kSCNetworkReachabilityFlagsReachable) == 0) {
         // if target host is not reachable
-        return NotReachable;
+        return UnReachable;
     }
 
-    NetworkStatus retVal = NotReachable;
+    NetworkStatusReachability retVal = UnReachable;
 
     if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0) {
         // if target host is reachable and no connection is required
         //  then we'll assume (for now) that your on Wi-Fi
-        retVal = ReachableViaWiFi;
+        retVal = ReachableOnWiFi;
     }
 
     if ((((flags & kSCNetworkReachabilityFlagsConnectionOnDemand) != 0) ||
@@ -201,14 +201,14 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 
         if ((flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0) {
             // ... and no [user] intervention is needed
-            retVal = ReachableViaWiFi;
+            retVal = ReachableOnWiFi;
         }
     }
 
     if ((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN) {
         // ... but WWAN connections are OK if the calling application
         //     is using the CFNetwork (CFSocketStream?) APIs.
-        retVal = ReachableViaWWAN;
+        retVal = ReachableOnWWAN;
     }
     return retVal;
 }
@@ -223,10 +223,10 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
     return NO;
 }
 
-- (NetworkStatus)currentReachabilityStatus
+- (NetworkStatusReachability)currentReachabilityStatus
 {
     NSAssert(reachabilityRef != NULL, @"currentNetworkStatus called with NULL reachabilityRef");
-    NetworkStatus retVal = NotReachable;
+    NetworkStatusReachability retVal = UnReachable;
     SCNetworkReachabilityFlags flags;
     if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) {
         retVal = [self networkStatusForFlags:flags];


### PR DESCRIPTION
Change the names of the enum values for NetworkStatus (now NetworkStatusReachability) so as to avoid conflicts with other plugins (background geolocation for instance)
